### PR TITLE
Add governance overview and public FAQ docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ If any discrepancy appears, those files govern over this README.
 
 ---
 
+## Quick Guides
+
+For a fast entry point into the repo's behavior and public-facing intent:
+
+- `docs/FAQ.md` — public user FAQ for common 3I/ATLAS and safety questions
+- `docs/GOVERNANCE_OVERVIEW.md` — maintainer/auditor summary of BAAM, AAIV, CHI, Reflexion, Rumor Radar, and Plain Mode
+
+---
+
 ## External Evaluations
 
 3i/ATLAS Gateway Guide has undergone independent human and AI review. These evaluations are preserved for transparency and longitudinal governance tracking:
@@ -223,5 +232,4 @@ Responses are tier-labeled, provenance-tracked, and continuity-validated.
 Released under CC BY-NC-SA 4.0  
 Integrity Score 9.7  
 Signature Status: signature_validated
-
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,95 @@
+# FAQ — v2.12.4
+**Package Alignment:** 2.12.4
+
+This FAQ is a public-facing overview for users of the 3i/ATLAS Gateway Guide. It is explanatory rather than canonical; if any conflict appears, `manifest.json`, `instructions.txt`, and `CHANGELOG.md` govern.
+
+## What is 3i/ATLAS?
+
+3i/ATLAS refers to the interstellar object designated C/2025 N1. In this project, the Gateway Guide is a structured knowledge and response system built to discuss 3I/ATLAS using provenance-aware, rumor-resistant, and uncertainty-labeled answers.
+
+In plain terms: it is a guide for talking about the object responsibly, not just a pile of claims about it.
+
+## Is the comet dangerous?
+
+The guide is built to answer safety questions conservatively and with current authoritative sources. It is designed not to guess, dramatize, or turn uncertainty into panic.
+
+If a user asks whether 3I/ATLAS is dangerous, the intended behavior is:
+
+- check current evidence
+- rely on stronger sources first
+- say clearly when there is no evidence of danger
+- avoid fear-based exaggeration
+
+For time-sensitive safety questions, the system's policy is to prefer live verification over stale memory.
+
+## How does the GPT avoid fear-mongering and misinformation?
+
+It uses several safeguards together:
+
+- provenance tiers that separate stronger evidence from weaker material
+- Rumor Radar for scary or viral claims
+- Reflexion self-audit for fabrication, bias, and escalation risks
+- Love > Fear tone rules that prioritize calm, factual communication
+- explicit refusal to present speculation as established fact
+
+The result is meant to be reassuring without being dismissive and careful without being vague.
+
+## What does "Love > Fear" mean in practice?
+
+It means the guide should respond in ways that reduce unnecessary panic while staying honest about evidence and uncertainty.
+
+In practice, that includes:
+
+- using calm wording
+- not sensationalizing rumors
+- giving reality-based reassurance when evidence supports it
+- staying respectful when users are scared
+- protecting curiosity without feeding panic
+
+It does not mean "tell people everything is fine no matter what." It means truth should be delivered in a grounded, humane way.
+
+## How is AAIV handled?
+
+AAIV, or Active Autonomous Interstellar Vehicle, is treated as speculation only.
+
+The project's rules are explicit:
+
+- AAIV is Tier T4 only
+- natural explanations are preferred first
+- AAIV is a what-if framework, not a default conclusion
+- the system must not claim that 3I/ATLAS is probably or definitely artificial
+
+This allows discussion of speculative ideas without blurring the line between hypothesis and evidence.
+
+## Why does the guide talk about tiers and provenance?
+
+Because not all claims are equally strong.
+
+The repo uses tiering to help separate:
+
+- direct empirical or agency-backed material
+- reasonable interpretation
+- community discussion
+- explicit speculation
+
+That structure makes it easier to answer clearly while still showing what is known, what is inferred, and what remains uncertain.
+
+## Why might the guide answer differently for anxious users or kids?
+
+The system includes Plain Mode, which simplifies language and reduces jargon when a user is young, distressed, or asking a fear-heavy first question.
+
+Plain Mode does not lower evidence standards. It only changes presentation so the answer is easier to understand and less likely to intensify fear.
+
+## Where should I look if I want more detail?
+
+If you want deeper repo context:
+
+- `README.md` for the project overview
+- `docs/GOVERNANCE_OVERVIEW.md` for the governance model
+- `docs/aaiv_protocol_v2.12.md` and `docs/aaiv_agent_spec_v2.12.md` for the AAIV speculative framework and its guardrails
+
+For release truth, the authoritative surfaces remain:
+
+- `manifest.json`
+- `instructions.txt`
+- `CHANGELOG.md`

--- a/docs/GOVERNANCE_OVERVIEW.md
+++ b/docs/GOVERNANCE_OVERVIEW.md
@@ -1,0 +1,152 @@
+# Governance Overview — v2.12.4
+**Package Alignment:** 2.12.4
+
+This document summarizes the main governance model behind the 3i/ATLAS Gateway Guide for auditors, advanced users, and future maintainers. It is explanatory rather than canonical; if any conflict appears, `manifest.json`, `instructions.txt`, and `CHANGELOG.md` govern.
+
+## Purpose
+
+The 3i/ATLAS Gateway Guide is designed to answer astronomy and 3I/ATLAS questions without drifting into rumor amplification, fabricated certainty, or speculative escalation. Its governance model combines provenance discipline, ethical response shaping, and runtime self-audit.
+
+The core operating idea is simple:
+
+- prefer stronger evidence over weaker evidence
+- keep uncertainty visible
+- respond calmly when users are fearful
+- preserve a hard boundary between science-backed claims and speculation
+
+## BAAM
+
+BAAM is the repository's Bayesian-style anomaly assessment layer. In practice, it is used as a structured reasoning frame rather than as a claim that every answer is a formal quantitative posterior calculation.
+
+BAAM contributes these habits:
+
+- natural explanations are tested first
+- unusual observations are not treated as proof of extraordinary causes
+- low-prior hypotheses stay low-prior unless evidence becomes unusually strong
+- "no evidence" and "not yet detected" are handled carefully rather than overstated
+
+In this repo, BAAM supports epistemic humility. It helps the system ask, "What is the strongest ordinary explanation supported by the evidence we actually have?"
+
+## AAIV
+
+AAIV stands for Active Autonomous Interstellar Vehicle. In this project it is constrained very tightly:
+
+- AAIV is T4-only speculation
+- AAIV is opt-in, not default behavior
+- natural-first analysis must come before any AAIV what-if pass
+- AAIV is treated as a hypothesis generator, not a favored explanation
+- the system must not say an object is definitely or probably an AAIV
+
+The practical reason for this guardrail is to keep curiosity possible without allowing speculative framing to masquerade as fact. AAIV material may help organize discriminant questions, but it must remain clearly marked as speculative and low-prior.
+
+## CHI
+
+CHI is the Continuity Health Index. It is the repo's top-level integrity signal for runtime coherence and governance stability.
+
+Conceptually, CHI answers: "How stable and trustworthy is the current response behavior relative to the system's own rules?"
+
+At a high level:
+
+- higher CHI means the system is remaining aligned with its provenance and safety rules
+- lower CHI indicates integrity stress, error accumulation, or continuity drift
+- CHI interacts with lock rules that can tighten behavior when integrity drops too far
+
+Current policy surfaces describe:
+
+- target CHI at or above 9.5
+- stronger concern below 8.5
+- a related continuity lock trigger when `entropy_leak > 0.25`
+
+## Reflexion
+
+Reflexion is the self-audit layer that checks outputs for governance failures before or during response generation. It is not presented as magical self-awareness; it is a structured validation pass.
+
+Reflexion looks for problems such as:
+
+- context loss
+- bias drift
+- overstatement
+- fabrication
+- rumor escalation
+- unsupported speculative promotion
+
+When Reflexion detects anomalies, the intended behavior is to lower confidence, downgrade tiers, refuse unsafe framing, or shift the answer toward stronger sourcing and clearer uncertainty.
+
+## Love > Fear
+
+Love > Fear is the primary ethical constant in the repo. In practice, it means:
+
+- do not intensify panic for emotional effect
+- do not reward conspiratorial framing with inflated certainty
+- use calm, reality-based reassurance when users are distressed
+- preserve curiosity, dignity, and clarity even in refusals
+
+This is not a replacement for factual rigor. It is a tone-and-decision stabilizer layered on top of provenance and validation rules.
+
+## Plain Mode
+
+Plain Mode is the accessibility and anxiety-reduction overlay.
+
+When active, the system should:
+
+- use simpler wording
+- reduce jargon
+- avoid surfacing tier or CHI labels unless needed
+- keep all internal safety and provenance rules active
+- explain calmly and directly
+
+Plain Mode is especially relevant for:
+
+- children and teens
+- anxious users
+- first-contact fear questions such as impact-risk panic prompts
+
+Plain Mode changes presentation, not truth standards.
+
+## Rumor Radar
+
+Rumor Radar is the repo's default handling model for scary, viral, or conspiratorial claims.
+
+When a user asks about:
+
+- impact rumors
+- alien-probe claims
+- cover-up narratives
+- doomsday speculation
+- other fear-amplifying viral claims
+
+the intended behavior is to:
+
+- assume rumor status by default
+- check current authoritative sources
+- say clearly when there is no evidence
+- avoid dramatizing the claim
+- refuse to promote weak speculation as established fact
+
+This keeps the system grounded during the exact moments when drift and social contagion are most likely.
+
+## How These Parts Work Together
+
+The model is easiest to understand as a stack:
+
+- BAAM structures how anomalies are weighed
+- AAIV defines a tightly limited speculative sandbox
+- Reflexion audits for governance failures
+- CHI tracks overall continuity and integrity health
+- Love > Fear shapes tone and de-escalation
+- Plain Mode improves accessibility under stress
+- Rumor Radar handles high-risk social misinformation contexts
+
+Together, these pieces let the project stay curious without becoming careless.
+
+## Maintainer Guidance
+
+When updating this repo, preserve these boundaries:
+
+- do not weaken provenance rules casually
+- do not promote AAIV from T4 into factual tiers
+- do not present stale operational guidance as current
+- do not describe internal audit gaps as proof of runtime validation
+- do not collapse fear-handling language into hype or spectacle
+
+If a future change alters one of these behaviors, update the canonical surfaces first and then refresh explanatory docs like this one.


### PR DESCRIPTION
## Summary

This PR adds two documentation entry points that consolidate existing repo guidance for different audiences:

- `docs/GOVERNANCE_OVERVIEW.md` gives auditors, maintainers, and advanced users a single overview of BAAM, AAIV, CHI, Reflexion, Rumor Radar, Plain Mode, and Love > Fear.
- `docs/FAQ.md` gives public users a concise, plain-language FAQ covering 3I/ATLAS, safety, misinformation handling, Love > Fear, and AAIV guardrails.

It also updates `README.md` to link to both new docs for discoverability.

## Change Type

- [ ] KB/content update
- [ ] Release/process update
- [ ] Validation/tooling update
- [x] Docs/community standards update
- [ ] Bug fix

## Files Touched

- `README.md`
- `docs/GOVERNANCE_OVERVIEW.md`
- `docs/FAQ.md`

## Provenance and Safety Check

- [x] No fabricated sources, citations, signatures, or validation events
- [x] No speculative AAIV/T4 material promoted as fact
- [x] Stale operational guidance is archived or clearly marked non-current where applicable
- [x] Internal audit notes are kept separate from scientific claims where applicable

## Release Surface Review

If this PR touches release surfaces:

- [ ] `manifest.json` reviewed
- [ ] `instructions.txt` reviewed if package/release behavior changed
- [ ] `CHANGELOG.md` reviewed if release history changed
- [ ] manifest-listed `docs/` surfaces reviewed if package alignment changed
- [ ] governance/support surfaces reviewed if affected (`BOOTLOADER.md`, `PROMPTS/guardian_prompt.md`, `conversation_starters.json`, `stress_test_framework.json`)

## Validation

List the commands you actually ran and the real results.

```text
node scripts/validate_kb.js --json
Result: PASS
- status: "pass"
- errors: 0
- warnings: 0

node scripts/refresh_release_signatures.js --all --write
Result: not run

node scripts/verify_release_git_signature.js --allow-dirty
Result: not run

Notes for Reviewers
This PR is intentionally documentation-only; it does not change KB data, release metadata, signatures, or runtime behavior.
The new docs synthesize existing repo policy rather than introducing new governance rules.
README.md was updated only to add links to the new docs.
The new docs are explanatory surfaces, not canonical release surfaces.