### PR TITLE
Fix release surface validation coverage

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,4 +1,5 @@
 # FAQ — v2.12.4
+**Version:** 2.12.4
 **Package Alignment:** 2.12.4
 
 This FAQ is a public-facing overview for users of the 3i/ATLAS Gateway Guide. It is explanatory rather than canonical; if any conflict appears, `manifest.json`, `instructions.txt`, and `CHANGELOG.md` govern.

--- a/docs/GOVERNANCE_OVERVIEW.md
+++ b/docs/GOVERNANCE_OVERVIEW.md
@@ -1,4 +1,5 @@
 # Governance Overview — v2.12.4
+**Version:** 2.12.4
 **Package Alignment:** 2.12.4
 
 This document summarizes the main governance model behind the 3i/ATLAS Gateway Guide for auditors, advanced users, and future maintainers. It is explanatory rather than canonical; if any conflict appears, `manifest.json`, `instructions.txt`, and `CHANGELOG.md` govern.

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,24 @@
       "version": "2.12.4",
       "purpose": "Deployment guide and governance overview (non-canonical; explanatory)"
     },
+    "docs/FAQ.md": {
+      "version": "2.12.4",
+      "filename": "docs/FAQ.md",
+      "purpose": "Public-facing FAQ for common 3I/ATLAS, safety, and governance questions",
+      "type": "faq",
+      "public_surface": true,
+      "status": "active",
+      "package_alignment_required": true
+    },
+    "docs/GOVERNANCE_OVERVIEW.md": {
+      "version": "2.12.4",
+      "filename": "docs/GOVERNANCE_OVERVIEW.md",
+      "purpose": "Maintainer and auditor overview of BAAM, AAIV, CHI, Reflexion, Rumor Radar, Plain Mode, and Love > Fear",
+      "type": "governance-overview",
+      "public_surface": true,
+      "status": "active",
+      "package_alignment_required": true
+    },
     "BOOTLOADER.md": {
       "version": "2.12.4",
       "filename": "BOOTLOADER.md",
@@ -111,6 +129,8 @@
     "knowledge_base_merged_v2.json": "Top-level version is 2.12.4 (kb_version 2.12.4; last_updated 2026-03-14T00:00:00Z).",
     "tags_index.json": "Top-level version is authoritative for manifest alignment; v2.12.4 adds live 3I/ATLAS and archival/audit tags with normalized counts.",
     "sources.json": "Top-level version is 2.12.4; sources_version 2.12.4 tracks the approved 2026-03-14 cumulative patch and preserves patch-backed provenance records.",
+    "docs/FAQ.md": "Version and Package Alignment markers track the current package release for public-facing user guidance.",
+    "docs/GOVERNANCE_OVERVIEW.md": "Version and Package Alignment markers track the current package release for maintainer and auditor guidance.",
     "docs/aaiv_protocol_v2.12.md": "Version remains 2.12.0; release review confirmed Package Alignment matches manifest v2.12.4.",
     "docs/aaiv_agent_spec_v2.12.md": "Version remains 2.12.0; release review confirmed Package Alignment matches manifest v2.12.4.",
     "bayesian_framework.json": "Framework surface intentionally remains at BAAM v2.11.2; release review must confirm manifest entry matches file version and preserve T4 guardrails.",
@@ -184,8 +204,8 @@
   "attribution": "Developed under BordneAI Ethical Operating System [EOS] with GCET Level 7+ meta-governance principles",
   "uuid": "3e23a554-7f87-43cd-9709-0f5808ce880f",
   "signature_status": "signature_validated",
-  "signature": "#ATLAS-SIG-MANIFEST-v2.12.4-Δ2026-03-15",
-  "fingerprint_sha256": "1474ee909a945f980f2f2feb3c27315249238313e0393f871c5958b92414329f",
+  "signature": "#ATLAS-SIG-MANIFEST-v2.12.4-Δ2026-04-29",
+  "fingerprint_sha256": "580348ae43e9f75a070b333db88981525254deaec3de47edb9080eff0d801abc",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
   "signature_blocking": false,
   "continuity_score": 9.7,
@@ -194,9 +214,9 @@
   "chi_enabled": true,
   "reflexion_hook_enabled": true,
   "public_audit_badge": true,
-  "signature_validated_at": "2026-03-15T04:47:29.604Z",
+  "signature_validated_at": "2026-04-29T19:44:32.704Z",
   "validated_by": "ATLAS-Local-Sign-v2.12.4",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-03-15T04:47:29.604Z.",
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T19:44:32.704Z.",
   "release_type": "patch",
   "last_updated": "2026-03-14",
   "update_ledger": [

--- a/scripts/validate_kb.js
+++ b/scripts/validate_kb.js
@@ -265,7 +265,8 @@ function validateLedgers(loaded, report) {
 function markdownFiles(manifest) {
   return Object.entries(manifest.files || {}).filter(([file, meta]) => {
     if (!file.endsWith(".md")) return false;
-    if (file === "README.md" || file === "CHANGELOG.md") return false;
+    if (file === "README.md") return false;
+    if (file === "CHANGELOG.md") return true;
     return meta && (meta.public_surface === true || meta.release_review === true);
   });
 }
@@ -282,11 +283,21 @@ function extractSignatureTokenVersion(raw) {
   const match = raw.match(/#ATLAS-SIG-[A-Z-]+-v(\d+\.\d+\.\d+)/);
   return match ? match[1] : null;
 }
+function extractChangelogTopVersion(raw) {
+  const match = raw.match(/^##\s+v(\d+\.\d+\.\d+)\b/m);
+  return match ? match[1] : null;
+}
 function validateMarkdownSurfaces(manifest, report) {
   markdownFiles(manifest).forEach(([file, meta]) => {
     report.files_checked.push(file);
     const raw = readText(file, report);
     if (raw == null) return;
+    if (file === "CHANGELOG.md") {
+      const topVersion = extractChangelogTopVersion(raw);
+      if (!topVersion) push(report, "errors", "changelog_version_missing", file, "CHANGELOG.md is missing a parsable top release heading like `## vX.Y.Z`.");
+      else if (topVersion !== manifest.version) push(report, "errors", "changelog_version_mismatch", file, `Top changelog version ${topVersion} does not match manifest.version ${manifest.version}.`);
+      return;
+    }
     const version = extractLabeledVersion(raw, "Version");
     const packageAlignment = extractLabeledVersion(raw, "Package Alignment");
     const titleVersion = extractTitleVersion(raw);


### PR DESCRIPTION
## Summary

This PR closes two release-surface governance gaps.

- It adds canonical `CHANGELOG.md` coverage to `scripts/validate_kb.js`, so the validator now checks that the top changelog release heading matches `manifest.version`.
- It registers `docs/FAQ.md` and `docs/GOVERNANCE_OVERVIEW.md` in `manifest.json` as public package-aligned surfaces.
- It adds explicit `Version` markers to those two docs so their package alignment can be enforced by the existing markdown-surface validator.

## Change Type

- [ ] KB/content update
- [x] Release/process update
- [x] Validation/tooling update
- [x] Docs/community standards update
- [x] Bug fix

## Files Touched

- `scripts/validate_kb.js`
- `manifest.json`
- `docs/FAQ.md`
- `docs/GOVERNANCE_OVERVIEW.md`

## Provenance and Safety Check

- [x] No fabricated sources, citations, signatures, or validation events
- [x] No speculative AAIV/T4 material promoted as fact
- [x] Stale operational guidance is archived or clearly marked non-current where applicable
- [x] Internal audit notes are kept separate from scientific claims where applicable

## Release Surface Review

If this PR touches release surfaces:

- [x] `manifest.json` reviewed
- [ ] `instructions.txt` reviewed if package/release behavior changed
- [ ] `CHANGELOG.md` reviewed if release history changed
- [x] manifest-listed `docs/` surfaces reviewed if package alignment changed
- [ ] governance/support surfaces reviewed if affected (`BOOTLOADER.md`, `PROMPTS/guardian_prompt.md`, `conversation_starters.json`, `stress_test_framework.json`)

## Validation

List the commands you actually ran and the real results.

```text
node scripts/refresh_release_signatures.js --write --files manifest.json
Result: PASS
- refreshed manifest.json signature metadata

node scripts/validate_kb.js --json
Result: PASS
- status: "pass"
- errors: 0
- warnings: 0
- files_checked includes CHANGELOG.md, docs/FAQ.md, and docs/GOVERNANCE_OVERVIEW.md

node scripts/verify_release_git_signature.js --allow-dirty
Result: not run

Notes for Reviewers
This PR intentionally does not change KB facts, source records, or runtime behavior.
CHANGELOG.md validation is intentionally lightweight: it enforces that the top release heading matches manifest.version.
manifest.json is a signed surface, so its signature metadata was refreshed as part of this change.
Follow-up: if desired, backfill GitHub issues for these two findings once gh is re-authenticated.
