### PR TITLE
Enforce normalized update ledger state

### DIFF
--- a/kb_updates_cumulative.json
+++ b/kb_updates_cumulative.json
@@ -2,8 +2,8 @@
   "audit_cycle_hours": 24,
   "chi_target": 9.7,
   "continuity_metrics": {
-    "average_continuity_weight": 0.97,
-    "integration_ratio": 0.71,
+    "average_continuity_weight": 0.9333,
+    "integration_ratio": 0.7143,
     "total_integrated": 5,
     "total_pending": 0,
     "total_rejected": 2,
@@ -12,7 +12,7 @@
   "description": "Knowledge Base Updates synchronized with BordneAI Phase-10 Continuity Protocols — Reflexion validation, CHI computation, and tier tagging integrated.",
   "filename": "kb_updates_cumulative.json",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
-  "fingerprint_sha256": "3e410ac7d1d813f268e4950562c006a11a209adb52c05c366d1544b7ad35bca2",
+  "fingerprint_sha256": "daf8407e5b8d3a5f262a79e300772737470927c0e4ca6b0ade32676e0aaa0a2d",
   "integrated": [
     {
       "approval_requirements": [
@@ -41,8 +41,8 @@
       "public_surface": false,
       "rationale": "Integrated evidence present in ledger; closed as integrated.",
       "required_domains": [
-        "ssd.jpl.nasa.gov",
-        "earthsky.org"
+        "earthsky.org",
+        "ssd.jpl.nasa.gov"
       ],
       "requires_web_search": false,
       "review_checklist": [
@@ -221,15 +221,15 @@
       "public_surface": false,
       "rationale": "Integrated evidence present in ledger; closed as integrated.",
       "required_domains": [
+        "arxiv.org",
+        "businesstimes.co",
+        "cfa.harvard.edu",
+        "economictimes.com",
         "mkaku.org",
         "people.com",
-        "businesstimes.co",
-        "usaherald.com",
-        "economictimes.com",
-        "cfa.harvard.edu",
-        "arxiv.org",
+        "ssd.jpl.nasa.gov",
         "ui.adsabs.harvard.edu",
-        "ssd.jpl.nasa.gov"
+        "usaherald.com"
       ],
       "requires_web_search": false,
       "review_checklist": [
@@ -240,7 +240,6 @@
       ],
       "review_owner": "science_editor@atlas",
       "source_ids_proposed": [
-        "MICHIO-KAKU-3I-ATLAS-TAG",
         "MICHIO-KAKU-3I-ATLAS-TAG",
         "LIGHTCURVE-3I-ATLAS-SANTANA-ROSS-2025",
         "LOEB-3I-ATLAS-HEARTBEAT-2025-11-30",
@@ -412,8 +411,8 @@
       "rejected_at": "2026-02-16T00:00:00Z",
       "rejection_reason": "No primary Galileo Project update or publication found on required domains as of 2026-02-16; avoid implying results exist.",
       "required_domains": [
-        "projects.iq.harvard.edu",
         "arxiv.org",
+        "projects.iq.harvard.edu",
         "ui.adsabs.harvard.edu"
       ],
       "requires_web_search": true,
@@ -441,13 +440,13 @@
       "blocked_by": "requires_web_search"
     }
   ],
-  "signature": "#ATLAS-SIG-UPDATES-v2.12.4-Δ2026-03-15",
-  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.12.4 | CC BY-NC-SA 4.0 | #ATLAS-SIG-UPDATES-v2.12.4-Δ2026-03-15",
+  "signature": "#ATLAS-SIG-UPDATES-v2.12.4-Δ2026-04-29",
+  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.12.4 | CC BY-NC-SA 4.0 | #ATLAS-SIG-UPDATES-v2.12.4-Δ2026-04-29",
   "signature_status": "signature_validated",
   "updates_version": "2.12.4",
   "verified_by": "EOS Transparency v2.11.2",
   "version": "2.12.4",
-  "signature_validated_at": "2026-03-15T04:47:29.604Z",
+  "signature_validated_at": "2026-04-29T19:58:57.219Z",
   "validated_by": "ATLAS-Local-Sign-v2.12.4",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-03-15T04:47:29.604Z."
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T19:58:57.219Z."
 }

--- a/scripts/validate_kb.js
+++ b/scripts/validate_kb.js
@@ -329,6 +329,26 @@ function validateGitSignature(opt, report) {
   result.errors.forEach((entry) => push(report, "errors", entry.code, entry.location, entry.message));
   result.warnings.forEach((entry) => push(report, "warnings", entry.code, entry.location, entry.message));
 }
+function validateNormalizedLedger(report) {
+  const result = spawnSync("node", ["scripts/normalize_updates.js", "--dry-run", "--json"], { cwd: ROOT, encoding: "utf8" });
+  if (result.error || result.status !== 0) {
+    const message = (result.error && result.error.message) || result.stderr || result.stdout || "Could not verify normalized ledger state.";
+    push(report, "errors", "normalize_updates_check_failed", "scripts/normalize_updates.js", message.trim());
+    return;
+  }
+  let summary;
+  try {
+    summary = JSON.parse(result.stdout);
+  } catch (error) {
+    push(report, "errors", "normalize_updates_parse_failed", "scripts/normalize_updates.js", error.message);
+    return;
+  }
+  if (summary && Array.isArray(summary.changes) && summary.changes.length > 0) {
+    summary.changes.forEach((entry) => {
+      push(report, "errors", "ledger_not_normalized", entry.location || "kb_updates_cumulative.json", entry.reason || "Ledger normalization drift detected.");
+    });
+  }
+}
 function render(report) {
   const lines = [`Overall status: ${report.errors.length ? "FAIL" : "PASS"}`, `Files checked (${report.files_checked.length}): ${report.files_checked.join(", ")}`];
   if (report.git_signature) {
@@ -369,6 +389,7 @@ function render(report) {
     refs.surfaced.forEach((id) => push(report, "errors", "quarantined_in_surfaced", "knowledge_base_merged_v2.json", `Quarantined source ${id} is cited in surfaced content.`));
   }
   validateLedgers(loaded, report);
+  validateNormalizedLedger(report);
   if (manifest) validateMarkdownSurfaces(manifest, report);
   validateGitSignature(opt, report);
   const summary = {


### PR DESCRIPTION
## Summary

This PR fixes two update-ledger hygiene issues:

- normalizes `kb_updates_cumulative.json` so the committed ledger matches canonical normalizer output
- tightens `scripts/validate_kb.js` so release validation now fails if the update ledger is not already normalized

Concretely, this removes a duplicate proposed source ID, normalizes deterministic array ordering, refreshes derived `continuity_metrics`, and prevents future normalization drift from shipping silently.

## Change Type

- [ ] KB/content update
- [x] Release/process update
- [x] Validation/tooling update
- [ ] Docs/community standards update
- [x] Bug fix

## Files Touched

- `kb_updates_cumulative.json`
- `scripts/validate_kb.js`

## Provenance and Safety Check

- [x] No fabricated sources, citations, signatures, or validation events
- [x] No speculative AAIV/T4 material promoted as fact
- [x] Stale operational guidance is archived or clearly marked non-current where applicable
- [x] Internal audit notes are kept separate from scientific claims where applicable

## Release Surface Review

If this PR touches release surfaces:

- [ ] `manifest.json` reviewed
- [ ] `instructions.txt` reviewed if package/release behavior changed
- [ ] `CHANGELOG.md` reviewed if release history changed
- [ ] manifest-listed `docs/` surfaces reviewed if package alignment changed
- [ ] governance/support surfaces reviewed if affected (`BOOTLOADER.md`, `PROMPTS/guardian_prompt.md`, `conversation_starters.json`, `stress_test_framework.json`)

## Validation

List the commands you actually ran and the real results.

```text
node scripts/normalize_updates.js --write --json
Result: PASS
- changes: 6
- deduped source_ids_proposed
- normalized required_domains ordering
- recomputed continuity_metrics

node scripts/refresh_release_signatures.js --write --files kb_updates_cumulative.json
Result: PASS
- refreshed kb_updates_cumulative.json signature metadata

node scripts/validate_kb.js --json
Result: PASS
- status: "pass"
- errors: 0
- warnings: 0

node scripts/normalize_updates.js --dry-run --json
Result: PASS
- changes: 0

node scripts/verify_release_git_signature.js --allow-dirty
Result: not run

Notes for Reviewers
This PR intentionally does not change KB facts or source registry contents; it normalizes the release ledger and strengthens enforcement.
kb_updates_cumulative.json is a signed surface, so its signature metadata was refreshed as part of the change.
The validator now shells out to scripts/normalize_updates.js --dry-run --json and treats any pending normalization changes as release validation errors.