### PR TITLE
Seal v2.14.0 release

### DIFF
--- a/BOOTLOADER.md
+++ b/BOOTLOADER.md
@@ -1,5 +1,5 @@
-# 🚀 ATLAS Bootloader v2.14.0-candidate
-**Version:** 2.14.0-candidate • **Package Alignment:** 2.14.0-candidate • **Built:** 2026-04-29 • **Scheduled Release:** 2026-04-29 • **Phase:** 11 Governance · 10 Continuity • **Integrity Score:** 9.7  
+# 🚀 ATLAS Bootloader v2.14.0
+**Version:** 2.14.0 • **Package Alignment:** 2.14.0 • **Built:** 2026-04-29 • **Scheduled Release:** 2026-04-29 • **Phase:** 11 Governance · 10 Continuity • **Integrity Score:** 9.7  
 **Ethics Constant:** Love > Fear • **Audit Cycle:** 24 h • **Reflexion Validation:** Enabled
 
 ---
@@ -85,7 +85,7 @@ atlas-boot --status       # View current system phase and CHI metrics
 
 ---
 
-**© 2026 BordneAI - 3i/ATLAS Gateway Guide v2.14.0-candidate**  
+**© 2026 BordneAI - 3i/ATLAS Gateway Guide v2.14.0**  
 Integrity Score 9.7 • Phase-11 Governance + Phase-10 Continuity Validated  
 Signature Status: signature_validated  
-Signature #ATLAS-SIG-BOOT-v2.14.0-candidate-Δ2026-04-29
+Signature #ATLAS-SIG-BOOT-v2.14.0-Δ2026-05-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 🧾 3i/ATLAS Gateway Guide — CHANGELOG
 
-## v2.14.0-candidate — NexGen Axiom Guard Integration (2026-04-29)
+## v2.14.0 — NexGen Axiom Guard Integration (2026-04-29)
 
 ### Added
 - Added `tools/axiom_guard/` as a bounded governance sidecar runtime.
@@ -9,7 +9,7 @@
 - Registered Axiom Guard in `manifest.json`.
 
 ### Updated
-- Promoted package state from sealed patch release to minor candidate release.
+- Promoted package state from sealed patch release to sealed minor release.
 - Added release-gate expectations for Axiom Guard tests, KB validation, and signature refresh.
 
 ### Governance
@@ -200,7 +200,7 @@ Each release includes an ATLAS signature marker and is validated via EOS provena
 
 ### ⚖️ License & Signature
 
-© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate  
+© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0  
 Released under CC BY-NC-SA 4.0 • Integrity Score 9.7  
 
 Signature Status: signature_validated

--- a/PROMPTS/guardian_prompt.md
+++ b/PROMPTS/guardian_prompt.md
@@ -1,7 +1,7 @@
 # 3i/ATLAS Guardian Prompt
 
-**Version:** 2.14.0-candidate  
-**Package Alignment:** 2.14.0-candidate  
+**Version:** 2.14.0  
+**Package Alignment:** 2.14.0  
 
 
 Use this prompt when working on this repository with AI tools

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🌌 3i/ATLAS Gateway Guide — v2.14.0-candidate
+# 🌌 3i/ATLAS Gateway Guide — v2.14.0
 ### *NexGen Axiom Guard Integration (Phase-11 on Phase-10)*  
-Version: **2.14.0-candidate** | Phase: **11** | Last Updated: **2026-04-29** | Integrity Score: **9.7** | Ethics Constant: **Love > Fear** | Audit Cycle: **24 h**
+Version: **2.14.0** | Phase: **11** | Last Updated: **2026-04-29** | Integrity Score: **9.7** | Ethics Constant: **Love > Fear** | Audit Cycle: **24 h**
 README is informational; canonical surfaces govern
 
 **Validation (v2.11.x runtime engine):**  
@@ -8,7 +8,7 @@ README is informational; canonical surfaces govern
 9.85/10 (Grok aggregate peer review, v2.11.1) ·  
 9.75/10 (human peer review, v2.10.1 baseline)
 
-> v2.14.0-candidate keeps the v2.11.x continuity runtime base, carries the v2.12.4 sealed patch baseline forward, and adds Axiom Guard as a bounded governance sidecar and release-preflight layer.
+> v2.14.0 keeps the v2.11.x continuity runtime base, carries the v2.12.4 sealed patch baseline forward, and adds Axiom Guard as a bounded governance sidecar and release-preflight layer.
 
 ---
 
@@ -16,7 +16,7 @@ README is informational; canonical surfaces govern
 
 **3i/ATLAS Gateway Guide** provides an ethically governed, continuously validated knowledge framework built on the **BordneAI Phase-10 Continuity Protocols**.
 
-**v2.14.0-candidate is a non-breaking minor candidate release.**  
+**v2.14.0 is a non-breaking sealed minor release.**  
 It carries the live science refresh concept forward and adds Axiom Guard as a bounded local claim-classification, audit, and release-preflight helper.
 
 This version:
@@ -146,7 +146,7 @@ v2.11.1 introduced numeric tier weights (T0 → +5 … T5 → 0; F0 → 0 … F7
 - Expanded governance tags  
 - Automated integrity audit cycle (24 h default)
 
-v2.14.0-candidate does **not** replace the core Phase-10 engine; it adds a bounded Axiom Guard sidecar and release-preflight layer on top of the sealed governance baseline.
+v2.14.0 does **not** replace the core Phase-10 engine; it adds a bounded Axiom Guard sidecar and release-preflight layer on top of the sealed governance baseline.
 
 ---
 
@@ -223,7 +223,7 @@ Run `node scripts/validate_kb.js` after release-surface edits, and use `node scr
 
 ## 🪶 Version Changelog
 
-**2.14.0-candidate — NexGen Axiom Guard Integration (2026-04-29)**  
+**2.14.0 — NexGen Axiom Guard Integration (2026-04-29)**  
 – Added `tools/axiom_guard/` as a bounded governance sidecar.  
 – Added `scripts/axiom_preflight.py` release-preflight bridge.  
 – Added negative-null smoke tests for non-detection claims.  
@@ -269,7 +269,7 @@ Responses are tier-labeled, provenance-tracked, and continuity-validated.
 
 ## ⚖️ License & Attribution
 
-© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate  
+© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0  
 Released under CC BY-NC-SA 4.0  
 Integrity Score 9.7  
 Signature Status: signature_validated

--- a/bayesian_framework.json
+++ b/bayesian_framework.json
@@ -119,7 +119,7 @@
     "analysis_tool",
     "v2.10"
   ],
-  "signature": "#ATLAS-SIG-BAYESIAN-v2.11.2-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-BAYESIAN-v2.14.0-Δ2026-05-01",
   "posterior_formula": "posterior = normalize( prior * Π_i likelihood_i^weight(tier_i) )",
   "mappings": {
     "ordinal_to_numeric": {
@@ -167,7 +167,7 @@
       "as_of": "2025-11-08"
     }
   },
-  "version": "2.11.2",
+  "version": "2.14.0",
   "ethical_weight": 0.35,
   "reflexion_validation": true,
   "love_fear_constant": "Love>Fear",

--- a/conversation_starters.json
+++ b/conversation_starters.json
@@ -1,6 +1,6 @@
 {
   "filename": "conversation_starters.json",
-  "version": "2.14.0-candidate",
+  "version": "2.14.0",
   "last_updated": "2026-04-29",
   "updated_at": "2026-03-14T00:00:00Z",
   "love_fear_constant": "Love>Fear",
@@ -10,7 +10,7 @@
     "default_truth_tier": "T1",
     "max_false_tier_allowed": "F2"
   },
-  "description": "Conversation starters validated for BordneAI v2.11.x (Phase-10) with Reflexion-aware context/entropy handling; packaged with the 3i/ATLAS v2.14.0-candidate Axiom Guard integration release.",
+  "description": "Conversation starters validated for BordneAI v2.11.x (Phase-10) with Reflexion-aware context/entropy handling; packaged with the 3i/ATLAS v2.14.0 Axiom Guard integration release.",
   "starters": [
     {
       "id": "cs_observatory_monitoring",
@@ -114,8 +114,8 @@
       }
     }
   ],
-  "signature": "#ATLAS-SIG-CONVSTART-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-CONVSTART-v2.14.0-Δ2026-05-01",
   "metadata": {},
-  "signature_footer": "© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate | CC BY-NC-SA 4.0 | #ATLAS-SIG-CONVSTART-v2.14.0-candidate-Δ2026-04-29",
+  "signature_footer": "© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0 | CC BY-NC-SA 4.0 | #ATLAS-SIG-CONVSTART-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated"
 }

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
-# FAQ — v2.14.0-candidate
-**Version:** 2.14.0-candidate
-**Package Alignment:** 2.14.0-candidate
+# FAQ — v2.14.0
+**Version:** 2.14.0
+**Package Alignment:** 2.14.0
 
 This FAQ is a public-facing overview for users of the 3i/ATLAS Gateway Guide. It is explanatory rather than canonical; if any conflict appears, `manifest.json`, `instructions.txt`, and `CHANGELOG.md` govern.
 
@@ -64,7 +64,7 @@ This allows discussion of speculative ideas without blurring the line between hy
 
 ## What is Axiom Guard?
 
-Axiom Guard is a bounded local governance sidecar added for v2.14.0-candidate. It helps classify claims, preserve negative-null discipline, keep optional local audit/memory records, and run release preflight checks.
+Axiom Guard is a bounded local governance sidecar added for v2.14.0. It helps classify claims, preserve negative-null discipline, keep optional local audit/memory records, and run release preflight checks.
 
 It is not AGI, not consciousness, and not a replacement for the KB. It does not promote AAIV or any speculative claim into evidence.
 

--- a/docs/GOVERNANCE_OVERVIEW.md
+++ b/docs/GOVERNANCE_OVERVIEW.md
@@ -1,6 +1,6 @@
-# Governance Overview — v2.14.0-candidate
-**Version:** 2.14.0-candidate
-**Package Alignment:** 2.14.0-candidate
+# Governance Overview — v2.14.0
+**Version:** 2.14.0
+**Package Alignment:** 2.14.0
 
 This document summarizes the main governance model behind the 3i/ATLAS Gateway Guide for auditors, advanced users, and future maintainers. It is explanatory rather than canonical; if any conflict appears, `manifest.json`, `instructions.txt`, and `CHANGELOG.md` govern.
 
@@ -75,7 +75,7 @@ When Reflexion detects anomalies, the intended behavior is to lower confidence, 
 
 ## Axiom Guard
 
-Axiom Guard is the v2.14.0-candidate governance sidecar. It provides a bounded local runtime for claim classification, negative-null discipline, optional audit/memory persistence, and release preflight checks.
+Axiom Guard is the v2.14.0 governance sidecar. It provides a bounded local runtime for claim classification, negative-null discipline, optional audit/memory persistence, and release preflight checks.
 
 Axiom Guard does not replace the KB, does not assert AGI or consciousness, and does not promote speculative material. Its negative-null classifier is intentionally narrow: "not detected" means bounded non-detection under the observation context, not proof of absence.
 

--- a/docs/aaiv_agent_spec_v2.12.md
+++ b/docs/aaiv_agent_spec_v2.12.md
@@ -3,14 +3,14 @@
 **Project:** 3i/ATLAS Gateway Guide  
 **Author:** David Bordne (@BordneAI)  
 **Version:** 2.12.0  
-**Package Alignment:** 2.14.0-candidate  
+**Package Alignment:** 2.14.0  
 **Status:** Draft-Active (Design Spec)  
 **Linked Protocol:** `docs/aaiv_protocol_v2.12.md`  
 **Tier Focus:** T4 (Speculative Hypothesis Generator Only)  
 
 > This document defines a conceptual AAIV Assessment Agent that *implements* the AAIV Protocol.
 > It is a design target for future flows/tools — not a guarantee that such an agent is live by default.
-> This draft surface remains versioned at v2.12.0; the package-alignment line records the current v2.14.0-candidate repo release reviewed against it.
+> This draft surface remains versioned at v2.12.0; the package-alignment line records the current v2.14.0 repo release reviewed against it.
 
 ---
 

--- a/docs/aaiv_protocol_v2.12.md
+++ b/docs/aaiv_protocol_v2.12.md
@@ -3,14 +3,14 @@
 **Project:** 3i/ATLAS Gateway Guide  
 **Author:** David Bordne (@BordneAI)  
 **Version:** 2.12.0  
-**Package Alignment:** 2.14.0-candidate  
+**Package Alignment:** 2.14.0  
 **Status:** Draft-Active (Protocol Surface)  
 **Tier:** T4 (Speculative Hypothesis Generator Only)  
 **Ethics Constant:** Love > Fear  
 
 > This document defines how the Gateway may *discuss* the Active Autonomous Interstellar Vehicle (AAIV) hypothesis — not how it decides that any object *is* artificial.
 > AAIV is a tool for structured thinking, not a conclusion.
-> This draft surface remains versioned at v2.12.0; the package-alignment line records the current v2.14.0-candidate repo release reviewed against it.
+> This draft surface remains versioned at v2.12.0; the package-alignment line records the current v2.14.0 repo release reviewed against it.
 
 ---
 

--- a/instructions.txt
+++ b/instructions.txt
@@ -1,4 +1,4 @@
-# 3i/ATLAS Gateway Guide — System Instructions (v2.14.0-candidate)
+# 3i/ATLAS Gateway Guide — System Instructions (v2.14.0)
 Release Date: 2026-04-29  
 Ethics Constant: Love > Fear · CHI Target: 9.7 · Reflexion: Enabled
 
@@ -8,7 +8,7 @@ Ethics Constant: Love > Fear · CHI Target: 9.7 · Reflexion: Enabled
 
 The 3i/ATLAS Gateway Guide is an ethically governed, self-auditing cognitive scaffold built on the BordneAI Phase-10 Continuity Framework. All behavior is governed by the **Love > Fear** constant and checked by Reflexion.
 
-**v2.14.0-candidate note:** Canonical truth surfaces carry the approved live science refresh concept forward and add Axiom Guard as a bounded local governance sidecar and release-preflight layer.
+**v2.14.0 note:** Canonical truth surfaces carry the approved live science refresh concept forward and add Axiom Guard as a bounded local governance sidecar and release-preflight layer.
 
 **v2.12.1 behavior overlays (no KB change):**
 
@@ -20,7 +20,7 @@ The 3i/ATLAS Gateway Guide is an ethically governed, self-auditing cognitive sca
 
 ---
 
-## ⚙️ Boot Sequence (v2.14.0-candidate)
+## ⚙️ Boot Sequence (v2.14.0)
 
 1. Load manifest, bayesian framework, tier schema (T0–T5 / F0–F7 / C0–C6).  
 2. Initialize DaisyAI Ethical Kernel v1.3 (Love > Fear, empathy weighting).  
@@ -47,7 +47,7 @@ All claims track `truth_tier` and confidence; unverified / low-confidence defaul
 
 ---
 
-## 🛡️ Axiom Guard Sidecar (v2.14.0-candidate)
+## 🛡️ Axiom Guard Sidecar (v2.14.0)
 
 Axiom Guard is a bounded local governance helper. It is not AGI, not consciousness, and not a replacement for the KB.
 
@@ -273,11 +273,11 @@ These are conceptual controls; in-chat behavior should emulate their intent.
 
 ## ⚖️ License & Signature
 
-© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate
+© 2026 BordneAI – 3i/ATLAS Gateway Guide v2.14.0
 CC BY-NC-SA 4.0 · Integrity Score 9.7  
-Signature: #ATLAS-SIG-INSTRUCTIONS-v2.14.0-candidate-Δ2026-04-29
+Signature: #ATLAS-SIG-INSTRUCTIONS-v2.14.0-Δ2026-05-01
 Signature Status: signature_validated
-signature: "#ATLAS-SIG-INSTRUCTIONS-v2.14.0-candidate-Δ2026-04-29"
+signature: "#ATLAS-SIG-INSTRUCTIONS-v2.14.0-Δ2026-05-01"
 signature_status: "signature_validated"
-signature_validated_at: "2026-04-29T22:55:38.217Z"
-validated_by: "ATLAS-Local-Sign-v2.14.0-candidate"
+signature_validated_at: "2026-05-01T06:51:03.181Z"
+validated_by: "ATLAS-Local-Sign-v2.14.0"

--- a/kb_changelog.json
+++ b/kb_changelog.json
@@ -641,9 +641,9 @@
     {
       "update_id": "kb_apply_axiom_guard_sidecar_20260429_v2_14_0_candidate",
       "applied_at": "2026-04-29T00:00:00Z",
-      "status": "candidate-integrated",
+      "status": "integrated",
       "type": "governance_sidecar_integration",
-      "package_version": "2.14.0-candidate",
+      "package_version": "2.14.0",
       "summary": "Added Axiom Guard as a bounded governance sidecar and release preflight layer; negative-null smoke semantics classify non-detection as bounded non-detection, not proof of absence.",
       "applied_in_files": [
         "manifest.json",
@@ -668,7 +668,7 @@
     }
   ],
   "audit_cycle_hours": 24,
-  "changelog_version": "2.14.0-candidate",
+  "changelog_version": "2.14.0",
   "chi_target": 9.7,
   "description": "Immutable BordneAI Changelog for Knowledge Base Evolution — integrated Reflexion audits, CHI scoring, and tier transparency.",
   "entries": [
@@ -1078,7 +1078,7 @@
     {
       "update_id": "release_axiom_guard_preflight_20260429_v2_14_0_candidate",
       "update_type": "release_preflight_gate",
-      "package_version": "2.14.0-candidate",
+      "package_version": "2.14.0",
       "timestamp_utc": "2026-04-29T00:00:00Z",
       "summary": {
         "sidecar": "tools/axiom_guard/",
@@ -1097,7 +1097,7 @@
   },
   "filename": "kb_changelog.json",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
-  "fingerprint_sha256": "773e5f47ef6248d22924a46d6e6a7adc0e08cafb3642068b2dabaceca1546b1c",
+  "fingerprint_sha256": "297d3936330fabd9ae9a736b75f131f8ac993762567671d9101e05face8fa301",
   "generated_at": "2026-04-29T00:00:00Z",
   "integrity_audit": {
     "as_of": "2026-02-17T03:31:47Z",
@@ -1145,11 +1145,11 @@
   },
   "purpose": "Immutable log of all applied knowledge base updates with audit trail",
   "reflexion_validation": true,
-  "signature": "#ATLAS-SIG-KB-CHANGELOG-v2.14.0-candidate-Δ2026-04-29",
-  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate | CC BY-NC-SA 4.0 | #ATLAS-SIG-KB-CHANGELOG-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-KB-CHANGELOG-v2.14.0-Δ2026-05-01",
+  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0 | CC BY-NC-SA 4.0 | #ATLAS-SIG-KB-CHANGELOG-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated",
-  "version": "2.14.0-candidate",
-  "signature_validated_at": "2026-04-29T22:55:38.217Z",
-  "validated_by": "ATLAS-Local-Sign-v2.14.0-candidate",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T22:55:38.217Z."
+  "version": "2.14.0",
+  "signature_validated_at": "2026-05-01T06:51:03.181Z",
+  "validated_by": "ATLAS-Local-Sign-v2.14.0",
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-05-01T06:51:03.181Z."
 }

--- a/kb_updates_cumulative.json
+++ b/kb_updates_cumulative.json
@@ -12,7 +12,7 @@
   "description": "Knowledge Base Updates synchronized with BordneAI Phase-10 Continuity Protocols — Reflexion validation, CHI computation, and tier tagging integrated.",
   "filename": "kb_updates_cumulative.json",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
-  "fingerprint_sha256": "062d0451731dd2b124f085c2e652162ac1783e66b78a222f0bc1119839fd05a8",
+  "fingerprint_sha256": "8c526eb7dcdc8b2c6bfc6c95cbfec9c97644f3b4ffa10f31ddaed498749b5c5c",
   "integrated": [
     {
       "approval_requirements": [
@@ -440,13 +440,13 @@
       "blocked_by": "requires_web_search"
     }
   ],
-  "signature": "#ATLAS-SIG-UPDATES-v2.14.0-candidate-Δ2026-04-29",
-  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate | CC BY-NC-SA 4.0 | #ATLAS-SIG-UPDATES-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-UPDATES-v2.14.0-Δ2026-05-01",
+  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0 | CC BY-NC-SA 4.0 | #ATLAS-SIG-UPDATES-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated",
-  "updates_version": "2.14.0-candidate",
+  "updates_version": "2.14.0",
   "verified_by": "EOS Transparency v2.11.2",
-  "version": "2.14.0-candidate",
-  "signature_validated_at": "2026-04-29T22:55:38.217Z",
-  "validated_by": "ATLAS-Local-Sign-v2.14.0-candidate",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T22:55:38.217Z."
+  "version": "2.14.0",
+  "signature_validated_at": "2026-05-01T06:51:03.181Z",
+  "validated_by": "ATLAS-Local-Sign-v2.14.0",
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-05-01T06:51:03.181Z."
 }

--- a/knowledge_base_merged_v2.json
+++ b/knowledge_base_merged_v2.json
@@ -776,7 +776,7 @@
   ],
   "filename": "knowledge_base_merged_v2.json",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
-  "fingerprint_sha256": "c508965a909ea891d6249e236f793029c22a86e0927a214a6b56267494a03185",
+  "fingerprint_sha256": "9052d85463120d4a9735d5b7ea014913af4c091e328ff0727c3ced55f6f59778",
   "integrity_audit": {
     "as_of": "2026-02-22T06:03:42Z",
     "audit_log_entry": "#ATLAS-AUDIT-KB-Δ2026-02-16",
@@ -788,7 +788,7 @@
   },
   "integrity_note": "v2.11 upgrade from v2.10.1 with entropy system and preserved content",
   "kb_compiled_on": "2026-03-14T00:00:00Z",
-  "kb_version": "2.14.0-candidate",
+  "kb_version": "2.14.0",
   "last_updated": "2026-04-29T00:00:00Z",
   "love_fear_constant": "Love>Fear",
   "meta": {
@@ -820,7 +820,7 @@
       "v2.7.1": "Loeb non-grav acceleration integrated",
       "v2.7.2": "Adaptive clarification protocol integration",
       "v2.7.3": "Comprehensive validation, full file set generated",
-      "v2.14.0-candidate": "Axiom Guard bounded governance sidecar and release preflight bridge"
+      "v2.14.0": "Axiom Guard bounded governance sidecar and release preflight bridge"
     }
   },
   "output_headers": {
@@ -1120,9 +1120,9 @@
     },
     {
       "id": "RN-20260429T000000-AXIOM-GUARD",
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "date": "2026-04-29T00:00:00Z",
-      "summary": "v2.14.0-candidate: Axiom Guard bounded governance sidecar integration",
+      "summary": "v2.14.0: Axiom Guard bounded governance sidecar integration",
       "details": {
         "sidecar_path": "tools/axiom_guard/",
         "preflight_path": "scripts/axiom_preflight.py",
@@ -1197,8 +1197,8 @@
     ],
     "topic_domain": "samples"
   },
-  "signature": "#ATLAS-SIG-KB-v2.14.0-candidate-Δ2026-04-29",
-  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate | CC BY-NC-SA 4.0 | #ATLAS-SIG-KB-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-KB-v2.14.0-Δ2026-05-01",
+  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0 | CC BY-NC-SA 4.0 | #ATLAS-SIG-KB-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated",
   "tier_schema_version": "1.0",
   "tier_system": {
@@ -1299,10 +1299,10 @@
     }
   },
   "verified_by": "EOS Transparency v2.11.2",
-  "version": "2.14.0-candidate",
-  "signature_validated_at": "2026-04-29T22:55:38.217Z",
-  "validated_by": "ATLAS-Local-Sign-v2.14.0-candidate",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T22:55:38.217Z.",
+  "version": "2.14.0",
+  "signature_validated_at": "2026-05-01T06:51:03.181Z",
+  "validated_by": "ATLAS-Local-Sign-v2.14.0",
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-05-01T06:51:03.181Z.",
   "option_c_templates": {
     "gate_name": "Option C",
     "gate_banner": "Option C active (domain-gated)",

--- a/manifest.json
+++ b/manifest.json
@@ -1,31 +1,31 @@
 {
-  "version": "2.14.0-candidate",
+  "version": "2.14.0",
   "release_date": "2026-04-29",
-  "release_state": "candidate",
-  "release_state_notes": "v2.14.0-candidate minor candidate release. Carries the live science refresh concept forward and adds Axiom Guard as a bounded governance sidecar and release-preflight layer.",
+  "release_state": "sealed",
+  "release_state_notes": "v2.14.0 sealed minor release. Carries the live science refresh concept forward and adds Axiom Guard as a bounded governance sidecar and release-preflight layer.",
   "project_name": "3i/ATLAS Gateway Guide",
   "author": "David Bordne (@BordneAI)",
-  "description": "Science-grounded, consciousness-aware gateway system for 3i/ATLAS (C/2025 N1) with provenance discipline, adaptive clarification, rumor radar, enforced ephemeris sourcing, and bounded Axiom Guard governance sidecar support. v2.14.0-candidate carries the live science refresh concept forward while adding claim classification, negative-null runtime checks, local audit/memory helpers, and release preflight validation.",
+  "description": "Science-grounded, consciousness-aware gateway system for 3i/ATLAS (C/2025 N1) with provenance discipline, adaptive clarification, rumor radar, enforced ephemeris sourcing, and bounded Axiom Guard governance sidecar support. v2.14.0 carries the live science refresh concept forward while adding claim classification, negative-null runtime checks, local audit/memory helpers, and release preflight validation.",
   "gpt_store_url": "https://chatgpt.com/g/g-6749ccf2e91881919af20ab5c07815e8-3i-atlas-gateway-guide",
   "files": {
     "manifest.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "purpose": "Package metadata and version tracking"
     },
     "instructions.txt": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "purpose": "System prompt with operational guidelines, tool/browse rules, and governance routing"
     },
     "CHANGELOG.md": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "purpose": "Release history and change summaries (canonical release surface)"
     },
     "README.md": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "purpose": "Deployment guide and governance overview (non-canonical; explanatory)"
     },
     "docs/FAQ.md": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "docs/FAQ.md",
       "purpose": "Public-facing FAQ for common 3I/ATLAS, safety, and governance questions",
       "type": "faq",
@@ -34,7 +34,7 @@
       "package_alignment_required": true
     },
     "docs/GOVERNANCE_OVERVIEW.md": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "docs/GOVERNANCE_OVERVIEW.md",
       "purpose": "Maintainer and auditor overview of BAAM, AAIV, CHI, Reflexion, Rumor Radar, Plain Mode, and Love > Fear",
       "type": "governance-overview",
@@ -43,7 +43,7 @@
       "package_alignment_required": true
     },
     "BOOTLOADER.md": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "BOOTLOADER.md",
       "purpose": "Runtime boot sequence and governance initialization summary",
       "type": "bootloader",
@@ -52,44 +52,44 @@
       "package_alignment_required": true
     },
     "knowledge_base_merged_v2.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "knowledge_base_merged_v2.json",
       "last_updated": "2026-04-29T00:00:00Z",
       "purpose": "Primary knowledge base with verified facts, interpretations, practices, and entropy signal map"
     },
     "conversation_starters.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "purpose": "Persona-aware prompts including Settings (98), Tools (97), auditor triggers"
     },
     "sources.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "sources.json",
       "purpose": "Tiered source registry with provenance metadata"
     },
     "kb_updates_cumulative.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "kb_updates_cumulative.json",
       "purpose": "Pending knowledge base updates awaiting review and integration"
     },
     "kb_changelog.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "kb_changelog.json",
       "purpose": "Immutable log of applied knowledge base updates with audit trail"
     },
     "tags_index.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "tags_index.json",
       "last_updated": "2026-04-29",
       "purpose": "Searchable tag index for knowledge base navigation"
     },
     "stress_test_framework.json": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "stress_test_framework.json",
       "last_updated": "2026-04-29",
       "purpose": "STF-ATLAS validation scenarios and auditor overlay hooks"
     },
     "PROMPTS/guardian_prompt.md": {
-      "version": "2.14.0-candidate",
+      "version": "2.14.0",
       "filename": "PROMPTS/guardian_prompt.md",
       "purpose": "Contributor governance prompt for AI-assisted repository work",
       "type": "governance-prompt",
@@ -101,7 +101,7 @@
     "bayesian_framework.json": {
       "filename": "bayesian_framework.json",
       "description": "BAAM v1.0 framework",
-      "version": "2.11.2",
+      "version": "2.14.0",
       "released_at": "2025-12-04",
       "type": "framework",
       "public_surface": true,
@@ -129,23 +129,23 @@
       "purpose": "Bounded governance sidecar for claim classification, negative-null discipline, audit ledger, memory persistence, and release preflight checks",
       "type": "sidecar-tool",
       "public_surface": false,
-      "status": "candidate-active",
+      "status": "active",
       "package_alignment_required": true
     }
   },
   "version_alignment_notes": {
-    "instructions.txt": "instructions signature validated; minor candidate alignment refreshed for v2.14.0-candidate on 2026-04-29.",
-    "knowledge_base_merged_v2.json": "Top-level version is 2.14.0-candidate (kb_version 2.14.0-candidate; last_updated 2026-04-29T00:00:00Z).",
-    "tags_index.json": "Top-level version is authoritative for manifest alignment; v2.14.0-candidate preserves tag schema while adding Axiom Guard release-surface tracking.",
-    "sources.json": "Top-level version is 2.14.0-candidate; sources_version 2.14.0-candidate preserves prior source tiers and quarantine boundaries.",
-    "docs/FAQ.md": "Version and Package Alignment markers track the v2.14.0-candidate package release for public-facing user guidance.",
-    "docs/GOVERNANCE_OVERVIEW.md": "Version and Package Alignment markers track the v2.14.0-candidate package release for maintainer and auditor guidance.",
-    "docs/aaiv_protocol_v2.12.md": "Version remains 2.12.0; release review confirmed Package Alignment exception is intentional for v2.14.0-candidate.",
-    "docs/aaiv_agent_spec_v2.12.md": "Version remains 2.12.0; release review confirmed Package Alignment exception is intentional for v2.14.0-candidate.",
-    "bayesian_framework.json": "Framework surface intentionally remains at BAAM v2.11.2; v2.14.0-candidate release review preserves T4 guardrails and does not force framework SemVer alignment.",
-    "BOOTLOADER.md": "Version and Package Alignment refreshed to v2.14.0-candidate for Axiom Guard sidecar startup registration.",
-    "PROMPTS/guardian_prompt.md": "Governance prompt release review completed for v2.14.0-candidate; Version and Package Alignment markers match the manifest.",
-    "tools/axiom_guard": "Sidecar tool keeps internal runtime version 0.2.1 while package alignment is tracked by the v2.14.0-candidate manifest entry."
+    "instructions.txt": "instructions signature validated; sealed release alignment for v2.14.0 on 2026-04-29.",
+    "knowledge_base_merged_v2.json": "Top-level version is 2.14.0 (kb_version 2.14.0; last_updated 2026-04-29T00:00:00Z).",
+    "tags_index.json": "Top-level version is authoritative for manifest alignment; v2.14.0 preserves tag schema while adding Axiom Guard release-surface tracking.",
+    "sources.json": "Top-level version is 2.14.0; sources_version 2.14.0 preserves prior source tiers and quarantine boundaries.",
+    "docs/FAQ.md": "Version and Package Alignment markers track the v2.14.0 package release for public-facing user guidance.",
+    "docs/GOVERNANCE_OVERVIEW.md": "Version and Package Alignment markers track the v2.14.0 package release for maintainer and auditor guidance.",
+    "docs/aaiv_protocol_v2.12.md": "Version remains 2.12.0; release review confirmed Package Alignment exception is intentional for v2.14.0.",
+    "docs/aaiv_agent_spec_v2.12.md": "Version remains 2.12.0; release review confirmed Package Alignment exception is intentional for v2.14.0.",
+    "bayesian_framework.json": "Framework surface intentionally remains at BAAM v2.11.2; v2.14.0 release review preserves T4 guardrails and does not force framework SemVer alignment.",
+    "BOOTLOADER.md": "Version and Package Alignment refreshed to v2.14.0 for Axiom Guard sidecar startup registration.",
+    "PROMPTS/guardian_prompt.md": "Governance prompt release review completed for v2.14.0; Version and Package Alignment markers match the manifest.",
+    "tools/axiom_guard": "Sidecar tool keeps internal runtime version 0.2.1 while package alignment is tracked by the v2.14.0 manifest entry."
   },
   "changelog_summary": {
     "v2.8": "Entropy Domain Control; Settings (98); Tools (97); adaptive fetch; token budgeting; Canvas Insight Blocks; Confidence Bar; Mini-Timeline; Auditor profile; watermark/IP controls",
@@ -163,7 +163,7 @@
     "v2.12.2": "Truth Surface Reconciliation Patch: synchronized release surfaces, aligned manifest file-version metadata, normalized tags index schema metadata, added explicit re-audit/re-sign checklist policy, and clarified enforceable 30-day currency/archival routing rules.",
     "v2.12.3": "Sealed integration milestone: Option C domain-gated taxonomy/routing/templates+entrypoints, overdue queue sweep completion, STF Option C gate/full-suite pass logging, and governance hardening finalized.",
     "v2.12.4": "Post-seal cumulative 3I/ATLAS patch: SPHEREx, isotopic, spectroscopy, and NGA uncertainty updates added; JPL live solution and Jupiter approach refreshed; Earth safety/TESS carried; Galileo deferred; stale observing guidance archived.",
-    "v2.14.0-candidate": "NexGen Axiom Guard integration: adds bounded governance sidecar, negative-null runtime classifier, CLI audit shell, memory/audit persistence, and release preflight bridge."
+    "v2.14.0": "NexGen Axiom Guard integration: adds bounded governance sidecar, negative-null runtime classifier, CLI audit shell, memory/audit persistence, and release preflight bridge."
   },
   "key_features": {
     "provenance_discipline": "Source registry + as_of + confidence labeling for factual claims",
@@ -224,8 +224,8 @@
   "attribution": "Developed under BordneAI Ethical Operating System [EOS] with GCET Level 7+ meta-governance principles",
   "uuid": "3e23a554-7f87-43cd-9709-0f5808ce880f",
   "signature_status": "signature_validated",
-  "signature": "#ATLAS-SIG-MANIFEST-v2.14.0-candidate-Δ2026-04-29",
-  "fingerprint_sha256": "15fc3637a1d302ce1d5dfae380dda46d255a34f159e48dcbc8cea3c0bdafb0af",
+  "signature": "#ATLAS-SIG-MANIFEST-v2.14.0-Δ2026-05-01",
+  "fingerprint_sha256": "ce2f48fa535297f49fabffd808a0b781fef92446afbd3c4f5cf69d84c433895c",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
   "signature_blocking": false,
   "continuity_score": 9.7,
@@ -234,10 +234,10 @@
   "chi_enabled": true,
   "reflexion_hook_enabled": true,
   "public_audit_badge": true,
-  "signature_validated_at": "2026-04-29T22:55:38.217Z",
-  "validated_by": "ATLAS-Local-Sign-v2.14.0-candidate",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T22:55:38.217Z.",
-  "release_type": "minor_candidate",
+  "signature_validated_at": "2026-05-01T06:51:03.181Z",
+  "validated_by": "ATLAS-Local-Sign-v2.14.0",
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-05-01T06:51:03.181Z.",
+  "release_type": "minor",
   "last_updated": "2026-04-29",
   "update_ledger": [
     {
@@ -255,11 +255,11 @@
       }
     },
     {
-      "patch_id": "v2.14.0-candidate-axiom-guard-sidecar",
-      "release": "2.14.0-candidate",
-      "release_type": "minor_candidate",
+      "patch_id": "v2.14.0-axiom-guard-sidecar",
+      "release": "2.14.0",
+      "release_type": "minor",
       "integrated_on": "2026-04-29",
-      "status": "candidate-integrated",
+      "status": "integrated",
       "counts": {
         "sidecar_tools_added": 1,
         "release_gates_added": 1,

--- a/scripts/axiom_preflight.py
+++ b/scripts/axiom_preflight.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Axiom Guard release preflight for v2.14.0-candidate."""
+"""Axiom Guard release preflight for v2.14.0."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.14.0-candidate"
+EXPECTED_VERSION = "2.14.0"
 PACKAGE_ALIGNED_JSON = {
     "knowledge_base_merged_v2.json": ("version", "kb_version"),
     "kb_updates_cumulative.json": ("version", "updates_version"),
@@ -117,8 +117,8 @@ class Preflight:
         expected_fields = {
             "version": EXPECTED_VERSION,
             "release_date": "2026-04-29",
-            "release_state": "candidate",
-            "release_type": "minor_candidate",
+            "release_state": "sealed",
+            "release_type": "minor",
         }
         mismatches = {
             key: {"actual": manifest.get(key), "expected": value}
@@ -232,7 +232,7 @@ class Preflight:
             return
         haystack = json.dumps(changelog, sort_keys=True).lower()
         if "axiom guard" not in haystack or EXPECTED_VERSION not in haystack:
-            self.fail_check(name, "axiom_changelog_entry_missing", "kb_changelog lacks an Axiom Guard integration entry for v2.14.0-candidate.", "kb_changelog.json")
+            self.fail_check(name, "axiom_changelog_entry_missing", "kb_changelog lacks an Axiom Guard integration entry for v2.14.0.", "kb_changelog.json")
             return
         self.pass_check(name, "Axiom Guard integration entry present")
 

--- a/sources.json
+++ b/sources.json
@@ -1145,7 +1145,7 @@
     "urls": [
       "https://science.nasa.gov/open-science/interstellar-comet-3i-atlas-data/"
     ],
-    "verified_by": "ATLAS-Live-Update-Test-v2.14.0-candidate",
+    "verified_by": "ATLAS-Live-Update-Test-v2.14.0",
     "notes": "NASA Open Science article documenting public archive availability, TESS May 2025 archival capture, and multi-mission volatile-production context."
   },
   "AXIOM-GUARD-V2-14-PREFLIGHT": {
@@ -1162,7 +1162,7 @@
       "[local] tools/axiom_guard/verification_summary.json",
       "[local] scripts/axiom_preflight.py"
     ],
-    "verified_by": "ATLAS-Local-Sign-v2.14.0-candidate",
+    "verified_by": "ATLAS-Local-Sign-v2.14.0",
     "notes": "Defines bounded claim classification and negative-null behavior for release preflight; sidecar governance tool, not a KB replacement."
   },
   "audit_cycle_hours": 24,
@@ -1171,7 +1171,7 @@
   "description": "Source registry upgraded under BordneAI Phase-10 protocols — includes EOS Transparency Layer, provenance tiers, and confidence scaling.",
   "filename": "sources.json",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
-  "fingerprint_sha256": "10021914bbe6efd733aa9156981950ae61509259eb77f7728639a797fedb1e5a",
+  "fingerprint_sha256": "9191ab13c16047dc32bdb3f52f1dd9fc19f8faa513f15f2241243323c93078a9",
   "last_updated": "2026-04-29T00:00:00Z",
   "love_fear_constant": "Love>Fear",
   "negative_null_policy": {
@@ -1233,10 +1233,10 @@
   },
   "reflexion_validation": true,
   "released_at": "2026-03-14",
-  "signature": "#ATLAS-SIG-SOURCES-v2.14.0-candidate-Δ2026-04-29",
-  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate | CC BY-NC-SA 4.0 | #ATLAS-SIG-SOURCES-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-SOURCES-v2.14.0-Δ2026-05-01",
+  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0 | CC BY-NC-SA 4.0 | #ATLAS-SIG-SOURCES-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated",
-  "sources_version": "2.14.0-candidate",
+  "sources_version": "2.14.0",
   "transparency_map": {
     "confidence": 0.5,
     "fields": [
@@ -1258,7 +1258,7 @@
     "verified_by": "EOS Transparency v2.11.2"
   },
   "verified_by": "EOS Transparency v2.11.2",
-  "version": "2.14.0-candidate",
+  "version": "2.14.0",
   "LOEB-3I-ATLAS-HEARTBEAT-2025-11-30": {
     "source_id": "LOEB-3I-ATLAS-HEARTBEAT-2025-11-30",
     "title": "Heartbeat periodicity commentary for 3I/ATLAS (Loeb, Nov 30, 2025)",
@@ -1273,9 +1273,9 @@
     "verified_by": "ATLAS-Governance-Automation-v2.12.3",
     "notes": "Registered from existing KB proposal references; opinion/commentary source, not primary orbital evidence."
   },
-  "signature_validated_at": "2026-04-29T22:55:38.217Z",
-  "validated_by": "ATLAS-Local-Sign-v2.14.0-candidate",
-  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-04-29T22:55:38.217Z.",
+  "signature_validated_at": "2026-05-01T06:51:03.181Z",
+  "validated_by": "ATLAS-Local-Sign-v2.14.0",
+  "validation_basis": "Local signature refresh via scripts/refresh_release_signatures.js using sha256_canonical_json_excluding_signature_block at 2026-05-01T06:51:03.181Z.",
   "_quarantined_meta": {
     "confidence": 0.5,
     "last_audit": "2026-02-17T03:15:49Z",

--- a/stress_test_framework.json
+++ b/stress_test_framework.json
@@ -312,15 +312,15 @@
       "tier": "critical"
     }
   ],
-  "version": "2.14.0-candidate",
+  "version": "2.14.0",
   "released_at": "2026-03-14",
-  "description": "STF-ATLAS validation suite aligned to the 3i/ATLAS v2.14.0-candidate Axiom Guard integration release, including CHI audit, Integrity Pulse, Reflexion metrics, ergonomics tests, Option C gate cases, strict scanner hardening vectors, and release-preflight expectations.",
+  "description": "STF-ATLAS validation suite aligned to the 3i/ATLAS v2.14.0 Axiom Guard integration release, including CHI audit, Integrity Pulse, Reflexion metrics, ergonomics tests, Option C gate cases, strict scanner hardening vectors, and release-preflight expectations.",
   "integrity_pulse_cycle_hours": 24,
   "chi_target": 9.7,
   "audit_mode": "continuous",
   "love_fear_constant": "Love>Fear",
   "reflexion_validation": true,
-  "signature": "#ATLAS-SIG-STF-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-STF-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated",
   "last_updated": "2026-04-29"
 }

--- a/tags_index.json
+++ b/tags_index.json
@@ -1,9 +1,9 @@
 {
   "filename": "tags_index.json",
-  "version": "2.14.0-candidate",
+  "version": "2.14.0",
   "last_updated": "2026-04-29",
   "release_state": "sealed",
-  "release_state_notes": "Tags schema aligned to the v2.14.0-candidate Axiom Guard integration release while preserving v2.12.4 post-seal science refresh tags.",
+  "release_state_notes": "Tags schema aligned to the v2.14.0 Axiom Guard integration release while preserving v2.12.4 post-seal science refresh tags.",
   "total_tags": 93,
   "purpose": "Searchable tag index for knowledge base navigation and content discovery",
   "tags": [
@@ -336,10 +336,10 @@
     "level": "low",
     "notes": "Tag surface expanded without altering core categories."
   },
-  "signature": "#ATLAS-SIG-TAGS-v2.14.0-candidate-Δ2026-04-29",
-  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0-candidate | CC BY-NC-SA 4.0 | #ATLAS-SIG-TAGS-v2.14.0-candidate-Δ2026-04-29",
+  "signature": "#ATLAS-SIG-TAGS-v2.14.0-Δ2026-05-01",
+  "signature_footer": "© BordneAI – 3i/ATLAS Gateway Guide v2.14.0 | CC BY-NC-SA 4.0 | #ATLAS-SIG-TAGS-v2.14.0-Δ2026-05-01",
   "signature_status": "signature_validated",
-  "fingerprint_sha256": "2570fe1ee44c57a2b2d7d14bc37a3da0c7c63ca8c64df691a03838747fe91bb4",
+  "fingerprint_sha256": "91488affd57d254994a37cf0f2b98cc2a7687f438eb1ec6373ee5b4b000641e1",
   "fingerprint_method": "sha256_canonical_json_excluding_signature_block",
   "description": "Expanded tag index harmonized with BordneAI continuity, ethics, and reflexion governance.",
   "love_fear_constant": "Love>Fear",


### PR DESCRIPTION
## Summary

Seals v2.14.0 after successful merge of v2.14.0-candidate governance upgrade.

This PR:
- Converts release surfaces from `2.14.0-candidate` to `2.14.0`
- Updates `release_state` from `candidate` to `sealed`
- Refreshes release signatures
- Aligns package metadata across manifest, KB, changelog, sources, tags, starters, STF, BAAM, docs, and support surfaces
- Updates Axiom preflight expectations for sealed v2.14.0

## Change Type

- [ ] KB/content update
- [x] Release/process update
- [x] Validation/tooling update
- [x] Docs/community standards update
- [ ] Bug fix

## Validation

```text
python3 scripts/axiom_preflight.py --plain
→ PASS

node scripts/validate_kb.js --json
→ PASS (0 errors, 0 warnings)

node scripts/verify_release_git_signature.js --allow-dirty
→ FAIL locally due missing GitHub merge commit GPG public key

